### PR TITLE
fix(ci): add id-token permission to PO workflow

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Required for OIDC authentication with Claude Code Action